### PR TITLE
Solve #10, how to restrict logins to an AD group defined in group_var…

### DIFF
--- a/group_vars/hpcr1
+++ b/group_vars/hpcr1
@@ -4,3 +4,4 @@ CUDADIR: /usr/local/cuda-11.5/bin
 ADDOMAIN: student.aast.edu
 ADUSER: stadmin
 ADPASS: CNDC@aast
+ADGROUP: vpn\ hpcgrid

--- a/installCUDA.yml
+++ b/installCUDA.yml
@@ -111,6 +111,14 @@
               insertbefore: # end of pam-auth-update config
               line: session optional        pam_mkhomedir.so skel=/etc/skel umask=077
 
+    - name: Restrict group login
+      shell: realm deny --all && realm permit -g {{ ADGROUP }} && touch GroupRestriction
+      args:
+              creates: GroupRestriction
+
+    - name: End play
+      meta: end_play
+
     - name: Block novueau 
       lineinfile:
         path: /etc/modprobe.d/blacklist-nouveau.conf


### PR DESCRIPTION
1-Add a task Restrict group login, that restricts the logins to member of group defined in group_vars with variable ADGROUP.
2-Adding the variable to group_vars/hpcr1
