### PR TITLE
17 no gpu issue

### DIFF
--- a/installCUDA.yml
+++ b/installCUDA.yml
@@ -8,14 +8,8 @@
   vars:
           HOSTIP: "{{ ansible_default_ipv4.address }}"
 
-  tasks:
-          - name: Detect NVIDIA hardware
-            shell: "lshw -C display|grep -c vendor: NVIDIA"
-            register: nvidia_count
-            ignore_errors: yes
-
   roles:
-          #- initenv
-          #- joinad
+          - initenv
+          - joinad
           - installnvidia 
 

--- a/installCUDA.yml
+++ b/installCUDA.yml
@@ -8,7 +8,14 @@
   vars:
           HOSTIP: "{{ ansible_default_ipv4.address }}"
 
+  tasks:
+          - name: Detect NVIDIA hardware
+            shell: "lshw -C display|grep -c vendor: NVIDIA"
+            register: nvidia_count
+            ignore_errors: yes
+
   roles:
-          - initenv
-          - joinad
+          #- initenv
+          #- joinad
           - installnvidia 
+

--- a/roles/installnvidia/tasks/main.yml
+++ b/roles/installnvidia/tasks/main.yml
@@ -1,5 +1,11 @@
-    - name: End Play
+    - name: Detect NVIDIA hardware
+      shell: "lshw -C display|grep -c vendor: NVIDIA"
+      register: nvidia_count
+      ignore_errors: yes
+
+    - name: End if no nvidia GPU installed
       meta: end_play
+      when: nvidia_count['stdout']|int == 0
 
     - name: Block novueau 
       lineinfile:

--- a/roles/installnvidia/tasks/main.yml
+++ b/roles/installnvidia/tasks/main.yml
@@ -1,7 +1,11 @@
+########
+####Take care of something, here the lshw -c Display , display display deiveces connected. 
+###     The output passed to grep to count it. IF the NVIDIA found, the grep returns 1 as ST/OUT and 0 as exit code
+###             But when grep does not detect the work NVIDIA , it returns 0 as stdout, and 1 as exit code cause the grep failed.
     - name: Detect NVIDIA hardware
-      shell: "lshw -C display|grep -c vendor: NVIDIA"
+      shell: lshw -C display|grep -c NVIDIA
       register: nvidia_count
-      ignore_errors: yes
+      failed_when: nvidia_count.rc == -1
 
     - name: End if no nvidia GPU installed
       meta: end_play


### PR DESCRIPTION
Done, add a task to detect the NVIDIA, Detect NVIDIA hardware and modify the task name from End Play to End if no nvidia GPU installed, and add to it a condition that terminates the playbook if count of number of lines contains NVIDIA = 0.
Note:
, here the lshw -c Display , display display deiveces connected. 
###     The output passed to grep to count it. IF the NVIDIA found, the grep returns 1 as ST/OUT and 0 as exit code
###             But when grep does not detect the work NVIDIA , it returns 0 as stdout, and 1 as exit code cause the grep failed.